### PR TITLE
Add pop mode for Ninja Fruit game

### DIFF
--- a/Application/STM32N6570-DK/Inc/ninja_fruit_game.h
+++ b/Application/STM32N6570-DK/Inc/ninja_fruit_game.h
@@ -39,6 +39,12 @@ typedef enum {
     FRUIT_STATE_INACTIVE
 } FruitState_t;
 
+// Gameplay mode
+typedef enum {
+    NINJA_MODE_SLICE = 0,
+    NINJA_MODE_POP
+} NinjaGameMode_t;
+
 // Fruit structure
 typedef struct {
     float32_t x;                    // normalized screen coordinates (0.0 to 1.0)
@@ -63,6 +69,7 @@ typedef struct {
     uint32_t game_start_time;
     uint32_t level;                 // increases difficulty
     float32_t spawn_rate_multiplier; // increases spawn frequency
+    NinjaGameMode_t mode;           // slicing or pop mode
 } NinjaGame_t;
 
 // Swipe trajectory for slice detection
@@ -78,11 +85,13 @@ void NinjaGame_Init(NinjaGame_t *game);
 void NinjaGame_Update(NinjaGame_t *game, GestureDetector_t *gesture_detector, spe_pp_outBuffer_t *keypoints);
 void NinjaGame_Render(NinjaGame_t *game);
 void NinjaGame_Reset(NinjaGame_t *game);
+void NinjaGame_SetMode(NinjaGame_t *game, NinjaGameMode_t mode);
 
 // Private functions
 static void SpawnFruit(NinjaGame_t *game);
 static void UpdateFruits(NinjaGame_t *game);
 static void CheckSlices(NinjaGame_t *game, SwipeTrajectory_t *swipe);
+static void CheckBubblePops(NinjaGame_t *game, spe_pp_outBuffer_t *keypoints);
 static void RenderFruit(Fruit_t *fruit, uint32_t screen_width, uint32_t screen_height);
 static void RenderUI(NinjaGame_t *game);
 static uint8_t LineIntersectsCircle(float32_t x1, float32_t y1, float32_t x2, float32_t y2,

--- a/Application/STM32N6570-DK/Src/main.c
+++ b/Application/STM32N6570-DK/Src/main.c
@@ -157,6 +157,7 @@ int main(void)
   Gesture_Init(&gesture_detector);
   //Initialize ninja fruit game
   NinjaGame_Init(&ninja_game);
+  NinjaGame_SetMode(&ninja_game, NINJA_MODE_POP);
 
   /*** Camera Init ************************************************************/
   CameraPipeline_Init(&lcd_bg_area.XSize, &lcd_bg_area.YSize, &pitch_nn);

--- a/Application/STM32N6570-DK/Src/ninja_fruit_game.c
+++ b/Application/STM32N6570-DK/Src/ninja_fruit_game.c
@@ -40,6 +40,7 @@ void NinjaGame_Init(NinjaGame_t *game)
 
     game->spawn_rate_multiplier = 1.0f;
     game->level = 1;
+    game->mode = NINJA_MODE_SLICE;
 }
 
 void NinjaGame_Update(NinjaGame_t *game, GestureDetector_t *gesture_detector, spe_pp_outBuffer_t *keypoints)
@@ -80,39 +81,44 @@ void NinjaGame_Update(NinjaGame_t *game, GestureDetector_t *gesture_detector, sp
     // Update existing fruits
     UpdateFruits(game);
 
-    // Check for slicing gestures
-    GestureType_t detected_gesture = Gesture_GetCurrentDisplayGesture(gesture_detector);
+    if (game->mode == NINJA_MODE_SLICE) {
+        // Check for slicing gestures
+        GestureType_t detected_gesture = Gesture_GetCurrentDisplayGesture(gesture_detector);
 
-    if (detected_gesture == GESTURE_LEFT_ARM_SWIPE_LEFT ||
-        detected_gesture == GESTURE_LEFT_ARM_SWIPE_RIGHT ||
-        detected_gesture == GESTURE_RIGHT_ARM_SWIPE_LEFT ||
-        detected_gesture == GESTURE_RIGHT_ARM_SWIPE_RIGHT ||
-        detected_gesture == GESTURE_SWORD_OVERHEAD_STRIKE ||
-        detected_gesture == GESTURE_SWORD_SIDE_SLASH) {
+        if (detected_gesture == GESTURE_LEFT_ARM_SWIPE_LEFT ||
+            detected_gesture == GESTURE_LEFT_ARM_SWIPE_RIGHT ||
+            detected_gesture == GESTURE_RIGHT_ARM_SWIPE_LEFT ||
+            detected_gesture == GESTURE_RIGHT_ARM_SWIPE_RIGHT ||
+            detected_gesture == GESTURE_SWORD_OVERHEAD_STRIKE ||
+            detected_gesture == GESTURE_SWORD_SIDE_SLASH) {
 
-        // Create swipe trajectory from wrist movement
-        SwipeTrajectory_t swipe = {0};
+            // Create swipe trajectory from wrist movement
+            SwipeTrajectory_t swipe = {0};
 
-        // Get current wrist position
-        if (detected_gesture == GESTURE_LEFT_ARM_SWIPE_LEFT || detected_gesture == GESTURE_LEFT_ARM_SWIPE_RIGHT) {
-            swipe.end_x = keypoints[KEYPOINT_LEFT_WRIST].x_center;
-            swipe.end_y = keypoints[KEYPOINT_LEFT_WRIST].y_center;
-        } else {
-            swipe.end_x = keypoints[KEYPOINT_RIGHT_WRIST].x_center;
-            swipe.end_y = keypoints[KEYPOINT_RIGHT_WRIST].y_center;
+            // Get current wrist position
+            if (detected_gesture == GESTURE_LEFT_ARM_SWIPE_LEFT || detected_gesture == GESTURE_LEFT_ARM_SWIPE_RIGHT) {
+                swipe.end_x = keypoints[KEYPOINT_LEFT_WRIST].x_center;
+                swipe.end_y = keypoints[KEYPOINT_LEFT_WRIST].y_center;
+            } else {
+                swipe.end_x = keypoints[KEYPOINT_RIGHT_WRIST].x_center;
+                swipe.end_y = keypoints[KEYPOINT_RIGHT_WRIST].y_center;
+            }
+
+            // Estimate start position based on gesture direction
+            float32_t dx = (detected_gesture == GESTURE_LEFT_ARM_SWIPE_RIGHT ||
+                           detected_gesture == GESTURE_RIGHT_ARM_SWIPE_RIGHT) ? -0.2f : 0.2f;
+            float32_t dy = (detected_gesture == GESTURE_SWORD_OVERHEAD_STRIKE) ? -0.3f : 0.0f;
+
+            swipe.start_x = swipe.end_x + dx;
+            swipe.start_y = swipe.end_y + dy;
+            swipe.timestamp = current_time;
+            swipe.active = 1;
+
+            CheckSlices(game, &swipe);
         }
-
-        // Estimate start position based on gesture direction
-        float32_t dx = (detected_gesture == GESTURE_LEFT_ARM_SWIPE_RIGHT ||
-                       detected_gesture == GESTURE_RIGHT_ARM_SWIPE_RIGHT) ? -0.2f : 0.2f;
-        float32_t dy = (detected_gesture == GESTURE_SWORD_OVERHEAD_STRIKE) ? -0.3f : 0.0f;
-
-        swipe.start_x = swipe.end_x + dx;
-        swipe.start_y = swipe.end_y + dy;
-        swipe.timestamp = current_time;
-        swipe.active = 1;
-
-        CheckSlices(game, &swipe);
+    } else {
+        // Pop mode: check if wrists are inside fruit circles
+        CheckBubblePops(game, keypoints);
     }
 
     // Check game over condition
@@ -207,6 +213,45 @@ static void CheckSlices(NinjaGame_t *game, SwipeTrajectory_t *swipe)
                     case FRUIT_STRAWBERRY: base_score = 25; break;
                 }
 
+                game->score += base_score * game->level;
+            }
+        }
+    }
+}
+
+static void CheckBubblePops(NinjaGame_t *game, spe_pp_outBuffer_t *keypoints)
+{
+    float32_t lx = keypoints[KEYPOINT_LEFT_WRIST].x_center;
+    float32_t ly = keypoints[KEYPOINT_LEFT_WRIST].y_center;
+    float32_t rx = keypoints[KEYPOINT_RIGHT_WRIST].x_center;
+    float32_t ry = keypoints[KEYPOINT_RIGHT_WRIST].y_center;
+    float32_t radius = FRUIT_SIZE / 2.0f / 800.0f;
+    float32_t radius_sq = radius * radius;
+
+    for (int i = 0; i < MAX_FRUITS; i++) {
+        Fruit_t *fruit = &game->fruits[i];
+
+        if (fruit->state == FRUIT_STATE_FALLING) {
+            float32_t dx = lx - fruit->x;
+            float32_t dy = ly - fruit->y;
+            float32_t dist_left_sq = dx * dx + dy * dy;
+
+            dx = rx - fruit->x;
+            dy = ry - fruit->y;
+            float32_t dist_right_sq = dx * dx + dy * dy;
+
+            if (dist_left_sq <= radius_sq || dist_right_sq <= radius_sq) {
+                fruit->state = FRUIT_STATE_SLICED;
+                fruit->slice_time = HAL_GetTick();
+                fruit->slice_direction = 0;
+
+                uint32_t base_score = 10;
+                switch (fruit->type) {
+                    case FRUIT_APPLE: base_score = 10; break;
+                    case FRUIT_ORANGE: base_score = 15; break;
+                    case FRUIT_BANANA: base_score = 20; break;
+                    case FRUIT_STRAWBERRY: base_score = 25; break;
+                }
                 game->score += base_score * game->level;
             }
         }
@@ -354,4 +399,9 @@ void NinjaGame_Reset(NinjaGame_t *game)
     game->game_start_time = HAL_GetTick();
 
     // Could store high score for display
+}
+
+void NinjaGame_SetMode(NinjaGame_t *game, NinjaGameMode_t mode)
+{
+    game->mode = mode;
 }


### PR DESCRIPTION
## Summary
- Introduce gameplay mode enum and setters to switch between slicing and pop modes
- Implement wrist-in-circle detection for pop mode and integrate mode selection into update logic
- Default game initialization to slice mode and configure main to start in pop mode
